### PR TITLE
sub circuit transistor model support in cougar extraction

### DIFF
--- a/alliance/src/mbk/src/spi_drive.c
+++ b/alliance/src/mbk/src/spi_drive.c
@@ -584,9 +584,9 @@ char            *vss;
 char            *vdd;
 {
   lotrs_list	*scantrs;
-  int		 nb;
+  int		 nb, subckt;
   ht            *trname;
-  char           name[1024], *ptr ;
+  char           name[1024], *ptr, *model ;
 
   for( scantrs = ptfig->LOTRS, nb=1 ; scantrs ; scantrs = scantrs->NEXT, nb++ );
 
@@ -598,6 +598,8 @@ char            *vdd;
   {
     if( scantrs->TRNAME )
     {
+      model = spitransmodel( scantrs->TYPE );
+      subckt = spitranssubckt(model);
       if( gethtitem( trname, scantrs->TRNAME ) != EMPTYHT )
       {
         do
@@ -608,11 +610,17 @@ char            *vdd;
         }
         while( gethtitem( trname, ptr ) != EMPTYHT );
         addhtitem( trname, ptr, 1 );
-        tooutput( df, "M%s ", name );    
+        if(subckt) 
+          tooutput( df, "X%s ", name );
+        else
+          tooutput( df, "M%s ", name );
       }
       else
       {
-        tooutput( df, "M%s ", scantrs->TRNAME );
+        if(subckt) 
+          tooutput( df, "X%s ", scantrs->TRNAME );
+        else
+          tooutput( df, "M%s ", scantrs->TRNAME );
         addhtitem( trname, scantrs->TRNAME, 1 );
       }
     }
@@ -625,7 +633,10 @@ char            *vdd;
         ptr = namealloc( name );
       }
       while( gethtitem( trname, ptr ) != EMPTYHT );
-      tooutput( df, "M%s ", name );
+      if(subckt) 
+        tooutput( df, "X%s ", name );
+      else
+        tooutput( df, "M%s ", name );
       addhtitem( trname, ptr, 1 );
     }
 
@@ -668,7 +679,7 @@ char            *vdd;
       }
     }
 
-    tooutput( df, "%s ", spitransmodel( scantrs->TYPE ) );
+    tooutput( df, "%s ", model );
 #define SCALED(x,y) (double)((double)(x)/(double)(y))
 
     if(scantrs->LENGTH!=0)

--- a/alliance/src/mbk/src/spi_global.c
+++ b/alliance/src/mbk/src/spi_global.c
@@ -7,6 +7,8 @@
 #include <mlu.h>
 #include "spi_global.h"
 
+#define TRUE 1
+
 spimodel *SPIHEADMODEL = NULL;
 
 void spiloaderror( char*, int, char* );
@@ -78,6 +80,7 @@ void spiloadmodel( void )
     new->NEXT  = SPIHEADMODEL ;
     new->MODEL = namealloc( word );
     new->TYPE  = 0;
+    new->SUBCKT  = 0;
     SPIHEADMODEL = new;
 
     while( *buffer==' ' && *buffer )
@@ -124,6 +127,9 @@ void spiloadmodel( void )
       else
       if( strcasecmp( word, "HVIO" ) == 0 )
         new->TYPE = new->TYPE | TRANSHVIO;
+      else
+      if( strcasecmp( word, "SUBCKT" ) == 0 )
+        new->SUBCKT = TRUE;
       else
         spiloaderror( env, line, "Unknown option" );
  
@@ -179,6 +185,22 @@ char spitranstype( char *model )
   {
     if( strcasecmp(scan->MODEL, model) == 0 )
       return( scan->TYPE );
+  }
+
+  return(SPI_UNK_TRANS_TYPE);
+}
+
+char spitranssubckt( char *model )
+{
+  spimodel *scan;
+
+  if( !SPIHEADMODEL )
+    spiloadmodel();
+
+  for( scan = SPIHEADMODEL ; scan ; scan = scan->NEXT )
+  {
+    if( strcasecmp(scan->MODEL, model) == 0 )
+      return( scan->SUBCKT );
   }
 
   return(SPI_UNK_TRANS_TYPE);

--- a/alliance/src/mbk/src/spi_global.h
+++ b/alliance/src/mbk/src/spi_global.h
@@ -2,10 +2,12 @@ typedef struct spimodel {
   struct spimodel *NEXT;
   char            *MODEL;
   char             TYPE;
+  char             SUBCKT;
 }spimodel ;
 
 void spiloadmodel __P(( void ));
 char spitranstype __P(( char* ));
+char spitranssubckt __P(( char* ));
 char* spitransmodel __P(( char ));
 
 /* Valeur pour dire que le nom de modele de transistor passé à la fonction


### PR DESCRIPTION
In the file designated by MBK_SPI_MODEL, we can set SUBCKT keyword to designate that the transistor uses a sub circuit to represent the model.